### PR TITLE
add `MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME` in MakeFile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ IMAGE_REPOSITORY    := eu.gcr.io/gardener-project/gardener/machine-controller-ma
 IMAGE_TAG           := $(shell cat VERSION)
 PROVIDER_NAME       := AWS
 PROJECT_NAME        := gardener
+CONTROL_NAMESPACE 	:= <control-namespace>
 CONTROL_KUBECONFIG  := dev/control_kubeconfig.yaml
 TARGET_KUBECONFIG   := dev/target_kubeconfig.yaml
 
@@ -29,6 +30,10 @@ MC_IMAGE			:=
 # MCM_IMAGE			:= eu.gcr.io/gardener-project/gardener/machine-controller-manager:v0.39.0
 # MC_IMAGE			:= $(IMAGE_REPOSITORY):v0.7.0
 LEADER_ELECT 	    := "true"
+
+# If Integration Test Suite is to be run locally against clusters then export the below variable
+# with MCM deployment name in the cluster
+# MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME := machine-controller-manager
 
 #########################################
 # Rules for running helper scripts


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds `MACHINE_CONTROLLER_MANAGER_DEPLOYMENT_NAME` in MakeFile

**Which issue(s) this PR fixes**:
Fixes [#636](https://github.com/gardener/machine-controller-manager/issues/636)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
NONE
```
